### PR TITLE
Ensure slack_user table stays in sync with slack. Closes #22.

### DIFF
--- a/migrations/ipobaxc5.initialize.sql
+++ b/migrations/ipobaxc5.initialize.sql
@@ -12,9 +12,10 @@ CREATE TRIGGER updated_at BEFORE UPDATE ON slack_team
 
 CREATE TABLE slack_user (
   id SERIAL PRIMARY KEY,
-  slack_id TEXT NOT NULL,
+  slack_id TEXT NOT NULL UNIQUE CHECK(slack_id <> ''),
   slack_team_id INTEGER NOT NULL REFERENCES slack_team(id),
-  name TEXT NOT NULL CHECK(name <> ''),
+  is_active BOOLEAN NOT NULL DEFAULT false,
+  meta JSONB,
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMPTZ
 );

--- a/src/services/bot-runner.js
+++ b/src/services/bot-runner.js
@@ -1,6 +1,7 @@
 import createBot from '../bot';
 import BotRunner from '../util/bot-runner';
 import {query} from './db';
+import {initSlackUserSync} from './sync-slack';
 
 // Start and stop bots as-necessary, automatically deactivating any bots that
 // become inactive.
@@ -17,6 +18,8 @@ const botRunner = new BotRunner({
         query.teamDeactivate({token});
       }
     });
+    // Ensure slack_user table stays synchronized with Slack.
+    initSlackUserSync(token, bot);
     return bot;
   },
   destroyBot(bot) {

--- a/src/services/sync-slack.js
+++ b/src/services/sync-slack.js
@@ -1,0 +1,33 @@
+import {db} from './db';
+import sql from '../sql';
+
+// Update slack_user table to ensure all team userdata is current.
+function syncSlackUsers(token, users) {
+  return db.task(function() {
+    return db.tx(tx => tx.batch(users.map(user => {
+      // Don't sync bots.
+      if (user.is_bot || user.id === 'USLACKBOT') {
+        return null;
+      }
+      return db.none(sql.userInsertUpdate, {
+        token,
+        userId: user.id,
+        isActive: !user.deleted,
+        meta: user,
+      });
+    })));
+  });
+}
+
+export function initSlackUserSync(token, bot) {
+  // Get all user data when the bot connects.
+  bot.slack.rtmClient.on('authenticated', () => {
+    const {users} = bot.slack.rtmClient.dataStore;
+    syncSlackUsers(token, Object.keys(users).map(id => users[id]));
+  });
+
+  // Handle user data changes while connected.
+  bot.slack.rtmClient.on('user_change', ({user}) => {
+    syncSlackUsers(token, [user]);
+  });
+}

--- a/src/sql/current_expertise_values.sql
+++ b/src/sql/current_expertise_values.sql
@@ -6,5 +6,5 @@ FROM expertise_current cur
 INNER JOIN interest_scale i_scale ON (i_scale.id = cur.interest_scale_id)
 INNER JOIN experience_scale e_scale ON (e_scale.id = cur.experience_scale_id)
 INNER JOIN slack_user usr ON (usr.id = cur.slack_user_id)
-WHERE usr.slack_id = ${userId}
+WHERE usr.is_active = true AND usr.slack_id = ${userId}
 AND expertise_id = ${expertiseId}

--- a/src/sql/current_expertises_for_user.sql
+++ b/src/sql/current_expertises_for_user.sql
@@ -7,6 +7,6 @@ INNER JOIN interest_scale i_scale ON (i_scale.id = cur.interest_scale_id)
 INNER JOIN experience_scale e_scale ON (e_scale.id = cur.experience_scale_id)
 INNER JOIN slack_user usr ON (usr.id = cur.slack_user_id)
 INNER JOIN expertise exp ON (exp.id = cur.expertise_id)
-WHERE usr.slack_id = ${userId}
+WHERE usr.is_active = true AND usr.slack_id = ${userId}
 GROUP BY interest, experience
 ORDER BY interest, experience

--- a/src/sql/current_users_for_expertise.sql
+++ b/src/sql/current_users_for_expertise.sql
@@ -6,6 +6,6 @@ FROM expertise_current cur
 INNER JOIN interest_scale i_scale ON (i_scale.id = cur.interest_scale_id)
 INNER JOIN experience_scale e_scale ON (e_scale.id = cur.experience_scale_id)
 INNER JOIN slack_user usr ON (usr.id = cur.slack_user_id)
-WHERE expertise_id = ${expertiseId}
+WHERE usr.is_active = true AND expertise_id = ${expertiseId}
 GROUP BY interest, experience
 ORDER BY interest, experience

--- a/src/sql/outstanding_expertises_for_user.sql
+++ b/src/sql/outstanding_expertises_for_user.sql
@@ -5,7 +5,7 @@ SELECT
   cat.name AS category
 FROM slack_user usr, expertise exp
 INNER JOIN expertise_category cat ON (cat.id = exp.expertise_category_id)
-WHERE usr.slack_id = ${userId}
+WHERE usr.is_active = true AND usr.slack_id = ${userId}
 AND exp.description IS NOT NULL
 AND (
   SELECT COUNT(*)

--- a/src/sql/outstanding_users_for_expertise.sql
+++ b/src/sql/outstanding_users_for_expertise.sql
@@ -1,7 +1,7 @@
 SELECT
   ARRAY_AGG(usr.slack_id) AS users
 FROM slack_user usr, expertise exp
-WHERE exp.id = ${expertiseId}
+WHERE usr.is_active = true AND exp.id = ${expertiseId}
 AND (
   SELECT COUNT(*)
   FROM expertise_current cur

--- a/src/sql/user_insert_update.sql
+++ b/src/sql/user_insert_update.sql
@@ -1,0 +1,22 @@
+INSERT INTO slack_user (
+  slack_id,
+  slack_team_id,
+  is_active,
+  meta
+)
+VALUES (
+  ${userId},
+  (SELECT id FROM slack_team WHERE token = ${token}),
+  ${isActive},
+  ${meta}
+)
+ON CONFLICT (slack_id)
+DO UPDATE SET (
+  slack_team_id,
+  is_active,
+  meta
+) = (
+  (SELECT id FROM slack_team WHERE token = ${token}),
+  ${isActive},
+  ${meta}
+)


### PR DESCRIPTION
Notes:
- Importing Bocoup data won't work as-is because the Bocoup `employee` database doesn't have a per-user Slack User Id. Not sure how to fix this yet.
