### PR TITLE
Improve bocoup-import command. Closes #35.

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ require('dotenv').config();
 
 module.exports = {
   isProduction: process.env.NODE_ENV === 'production',
+  bocoupTeamId: 'T025GMFDP',
   app: {
     host: process.env.HOST || '0.0.0.0',
     port: process.env.PORT || '8000',

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -34,7 +34,12 @@ export default function createBot(token) {
       // Helper method to format the given command name.
       const getCommand = cmd => name ? `${name} ${cmd}` : cmd;
       // Dev-only commands.
-      const devCommands = [bocoupImportCommand];
+      const devCommands = [];
+      // Bocoup team-only commands.
+      const bocoupCommands = [];
+      if (bot.slack.rtmClient.activeTeamId === config.bocoupTeamId) {
+        bocoupCommands.push(bocoupImportCommand);
+      }
 
       const skillsCommand = createCommand({
         isParent: true,
@@ -49,6 +54,7 @@ export default function createBot(token) {
         scalesCommand,
         statsCommand,
         updateCommand,
+        ...bocoupCommands,
         ...(config.isProduction ? [] : devCommands),
       ]);
 


### PR DESCRIPTION
- The command can now only be run when connected to the Bocoup slack.
- The command is no longer a command, but a matcher, so it won't appear
  in the "help" list.
- The command will only run if no expertises or categories have been
  created yet.
