### PR TITLE
Add /skills slash command support.

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ module.exports = {
   tokens: {
     client_id: process.env.SLACK_CLIENT_ID,
     client_secret: process.env.SLACK_CLIENT_SECRET,
+    verification: process.env.SLACK_VERIFICATION_TOKEN,
   },
   db: {
     host: process.env.DB_HOST,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-register": "^6.4.3",
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.4.0",
+    "body-parser": "^1.15.2",
     "careen": "^0.1.1",
     "chatter": "^0.5.0",
     "dotenv": "^2.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -109,7 +109,7 @@ app.post('/command', (req, res) => {
     type: 'message',
     channel: dmId,
     user: userId,
-    text,
+    text: text || 'help',
   });
   // Show the actual command text if the slash command was used in the DM.
   if (dmId === channelId) {

--- a/src/util/bot-runner.js
+++ b/src/util/bot-runner.js
@@ -36,6 +36,11 @@ export default class BotRunner {
     }
   }
 
+  // Find the first bot for which "fn" returns true.
+  findBot(fn) {
+    return Object.keys(this.bots).map(k => this.bots[k]).find(fn);
+  }
+
   startOrStopBots() {
     this.getIntegrations().then(({active = [], inactive = []}) => {
       active.forEach(token => this.startBot(token));


### PR DESCRIPTION
#### How it works
1. Type `/skills <optional args>` from any channel.
2. This should cause Slack to POST a payload to `/command`.
3. Slack should send a message back to you in the channel in which you used `/skills`.
   - If the channel is a DM with the bot, ti should echo the command back to you.
   - Otherwise, it should instruct you to check your DM with the bot.
4. The app should simulate a message to the bot from you in a DM.
5. The bot should respond in the DM.
#### Notes
- Slash command responses use the app icon, which is currently the default. Once the app has an icon, it'll look better.
- I don't think it's possible to have the app NOT respond to a slash command, as far as I can tell, it will always need to display something.
#### Testing with your own app

As part of Slack app setup, before running the bot:
1. Click on "App Credentials" in the left nav.
2. Make note of the Verification Token and add it to your `.env` file like so:
   - `SLACK_VERIFICATION_TOKEN=your_verification_token_value`
3. Click on "Slash Commands" in the left nav.
4. Click "Create new command".
5. Enter these settings:
   - Command: `/skills`
   - Request URL: `https://c863a1e3.ngrok.io/command` (use your ngrok url + `/command`)
   - Short Description: `Show your skills.`
   - Usage hint: `[command]`
6. Click "Save".

If you've already added the app to Slack, you'll have to refresh the ngrok server page with the "Add to Slack" button and re-add it, so the new `commands` scope is added to the integration. This shouldn't require changing or re-importing the database.
