### PR TITLE
Refactor commands to clean up promise logic / output buffering.

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -36,7 +36,7 @@ export default function createBot(token) {
       // Helper method to format the given command name.
       const getCommand = cmd => name ? `${name} ${cmd}` : cmd;
       // Dev-only commands.
-      const devCommands = [];
+      const devCommands = [adminCommand];
       // Bocoup team-only commands.
       const bocoupCommands = [];
       if (bot.slack.rtmClient.activeTeamId === config.bocoupTeamId) {
@@ -56,7 +56,6 @@ export default function createBot(token) {
         scalesCommand,
         statsCommand,
         updateCommand,
-        adminCommand,
         versionCommand,
         ...bocoupCommands,
         ...(config.isProduction ? [] : devCommands),

--- a/src/bot/lib/output-buffer.js
+++ b/src/bot/lib/output-buffer.js
@@ -1,0 +1,24 @@
+export default class OutputBuffer {
+  constructor() {
+    this.output = [];
+  }
+  // Add a message into the output to eventually be flushed.
+  // Return this so that it's chainable.
+  push(message) {
+    if (message) {
+      this.output.push(message);
+    }
+    return this;
+  }
+  // Flush the buffer. Use this method when you only need to return the
+  // buffer (at the top level).
+  flush() {
+    return this.output;
+  }
+  // Flush the buffer. Use this method when you only need to return both a
+  // value and the buffer. "obj" is an object that will be merged with an
+  // {output: ...} object containing the buffer array.
+  result(obj = {}) {
+    return Object.assign({}, obj, {output: this.output});
+  }
+}


### PR DESCRIPTION
Outputting-as-you-go, like what we traditionally do with `console.log`, doesn't really work for Slack bots, since you need to send the entire message all-at-once, at the end.

Basically, instead of doing this:

``` js
function doThing() {
  console.log('first');
  console.log('second');
}
```

You really need to do this:

``` js
function doThing() {
  const buffer = [];
  buffer.push('first');
  buffer.push('second');
  return buffer;
}
```

Which gets complicated if an external function also has both buffered output AND an actual result:

``` js
function doThing() {
  const buffer = [];
  buffer.push('first');
  const {result, output} = externalFunction();
  buffer.push(output);
  if (result) {
    buffer.push('third');
  }
  return buffer;
}

function externalFunction() {
  const buffer = [];
  buffer.push('external');
  return {
    result: true,
    output: buffer,
  };
}
```

But writing the code to return objects in external functions can be pretty onerous. So I wrote a little helper class called [OutputBuffer](https://github.com/bocoup/skillsbot/blob/admin/src/bot/lib/output-buffer.js) that makes this a little prettier:

``` js
function externalFunction() {
  const buffer = new OutputBuffer();
  buffer.push('external');
  return buffer.result({result: true});
}
```

Either way, this is how you'd write a command now:
- https://github.com/bocoup/skillsbot/blob/admin/src/bot/commands/admin/add-category.js
- https://github.com/bocoup/skillsbot/blob/admin/src/bot/commands/find.js

And this is how an external function buffers its output:
- https://github.com/bocoup/skillsbot/blob/admin/src/bot/lib/matching.js#L23-L47
