### PR TITLE
Refactor category admin commands. Closes #39, #40, #41.

### DIFF
--- a/migrations/irdx0dee.category_is_active.sql
+++ b/migrations/irdx0dee.category_is_active.sql
@@ -1,0 +1,3 @@
+ALTER TABLE skill_category ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT true;
+---
+ALTER TABLE skill_category DROP COLUMN is_active;

--- a/src/bot/commands/admin.js
+++ b/src/bot/commands/admin.js
@@ -4,8 +4,9 @@
 import {createCommand} from 'chatter';
 
 // import Sub-commands
-import categoryAdd from './admin/category-add';
 import categoryList from './admin/category-list';
+import categoryInfo from './admin/category-info';
+import categoryAdd from './admin/category-add';
 import categoryUpdate from './admin/category-update';
 import {categoryActivate, categoryDeactivate} from './admin/category-activate';
 
@@ -14,6 +15,7 @@ export default createCommand({
   description: 'Admin commands',
 }, [
   categoryList,
+  categoryInfo,
   categoryAdd,
   categoryUpdate,
   categoryActivate,

--- a/src/bot/commands/admin.js
+++ b/src/bot/commands/admin.js
@@ -4,18 +4,18 @@
 import {createCommand} from 'chatter';
 
 // import Sub-commands
-import addCategory from './admin/add-category';
+import categoryAdd from './admin/category-add';
 import categoryList from './admin/category-list';
-import updateCategory from './admin/update-category';
-import {activateCategory, deactivateCategory} from './admin/activate-category';
+import categoryUpdate from './admin/category-update';
+import {categoryActivate, categoryDeactivate} from './admin/category-activate';
 
 export default createCommand({
   name: 'admin',
   description: 'Admin commands',
 }, [
   categoryList,
-  addCategory,
-  updateCategory,
-  activateCategory,
-  deactivateCategory,
+  categoryAdd,
+  categoryUpdate,
+  categoryActivate,
+  categoryDeactivate,
 ]);

--- a/src/bot/commands/admin.js
+++ b/src/bot/commands/admin.js
@@ -5,6 +5,7 @@ import {createCommand} from 'chatter';
 
 // import Sub-commands
 import addCategory from './admin/add-category';
+import categoryList from './admin/category-list';
 import updateCategory from './admin/update-category';
 import {activateCategory, deactivateCategory} from './admin/activate-category';
 
@@ -12,6 +13,7 @@ export default createCommand({
   name: 'admin',
   description: 'Admin commands',
 }, [
+  categoryList,
   addCategory,
   updateCategory,
   activateCategory,

--- a/src/bot/commands/admin.js
+++ b/src/bot/commands/admin.js
@@ -8,7 +8,7 @@ import categoryList from './admin/category-list';
 import categoryInfo from './admin/category-info';
 import categoryAdd from './admin/category-add';
 import categoryUpdate from './admin/category-update';
-import {categoryActivate, categoryDeactivate} from './admin/category-activate';
+import {categoryEnable, categoryDisable} from './admin/category-enable-disable';
 
 export default createCommand({
   name: 'admin',
@@ -18,6 +18,6 @@ export default createCommand({
   categoryInfo,
   categoryAdd,
   categoryUpdate,
-  categoryActivate,
-  categoryDeactivate,
+  categoryEnable,
+  categoryDisable,
 ]);

--- a/src/bot/commands/admin.js
+++ b/src/bot/commands/admin.js
@@ -6,8 +6,7 @@ import {createCommand} from 'chatter';
 // import Sub-commands
 import addCategory from './admin/add-category';
 import updateCategory from './admin/update-category';
-import activateCategory from './admin/activate-category';
-import deactivateCategory from './admin/deactivate-category';
+import {activateCategory, deactivateCategory} from './admin/activate-category';
 
 export default createCommand({
   name: 'admin',

--- a/src/bot/commands/admin/activate-category.js
+++ b/src/bot/commands/admin/activate-category.js
@@ -1,9 +1,42 @@
+import {query} from '../../../services/db';
 import {createCommand, createParser} from 'chatter';
+import {getBestMatch} from '../../lib/matching';
 
-export default createCommand({
+const activateHander = isActive => ({args}, {bot, token, getCommand}) => {
+  const search = args.join(' ');
+  if (!search) {
+    return false;
+  }
+  // Create a buffer in which output messages can accumulate.
+  const buffer = [];
+  // Find matching categories.
+  return query.categoryByName({token, search})
+  .then(matches => {
+    // Test if match is good, ambiguous, etc.
+    const {match, output} = getBestMatch(search, matches);
+    // Add any output from the test to the buffer.
+    buffer.push(output);
+    // Exit now if match was ambiguous.
+    if (!match) {
+      return buffer;
+    }
+    // Deactivate the category.
+    return query.categorySetActive({categoryId: match.id, isActive})
+    .then(() => [
+      ...buffer,
+      `_You have successfully ${isActive ? '' : 'de'}activated category "${search}"._`,
+    ]);
+  });
+};
+
+export const activateCategory = createCommand({
   name: 'activate category',
-  description: 'Activate a new skills category.',
+  description: 'Activate a skill category.',
   usage: '<category name>',
-}, createParser(({args}) => {
-  return 'activate category command coming soon';
-}));
+}, createParser(activateHander(true)));
+
+export const deactivateCategory = createCommand({
+  name: 'deactivate category',
+  description: 'Deactivate a skill category.',
+  usage: '<category name>',
+}, createParser(activateHander(false)));

--- a/src/bot/commands/admin/category-activate.js
+++ b/src/bot/commands/admin/category-activate.js
@@ -29,14 +29,14 @@ const activateHander = isActive => ({args}, {bot, token, getCommand}) => {
   });
 };
 
-export const activateCategory = createCommand({
-  name: 'activate category',
+export const categoryActivate = createCommand({
+  name: 'category activate',
   description: 'Activate a skill category.',
   usage: '<category name>',
 }, createParser(activateHander(true)));
 
-export const deactivateCategory = createCommand({
-  name: 'deactivate category',
+export const categoryDeactivate = createCommand({
+  name: 'category deactivate',
   description: 'Deactivate a skill category.',
   usage: '<category name>',
 }, createParser(activateHander(false)));

--- a/src/bot/commands/admin/category-activate.js
+++ b/src/bot/commands/admin/category-activate.js
@@ -2,7 +2,7 @@ import {query} from '../../../services/db';
 import {createCommand, createParser} from 'chatter';
 import {getBestMatch} from '../../lib/matching';
 
-const activateHander = isActive => ({args}, {bot, token, getCommand}) => {
+const activateHander = isActive => ({args}, {token}) => {
   const search = args.join(' ');
   if (!search) {
     return false;

--- a/src/bot/commands/admin/category-add.js
+++ b/src/bot/commands/admin/category-add.js
@@ -3,8 +3,8 @@ import {createCommand, createParser} from 'chatter';
 import {testDuplicateMatch} from '../../lib/matching';
 
 export default createCommand({
-  name: 'add category',
-  description: 'Add a new skills category.',
+  name: 'category add',
+  description: 'Add a new skill category.',
   usage: '<category name>',
 }, createParser(({args}, {bot, token, getCommand}) => {
   const search = args.join(' ');

--- a/src/bot/commands/admin/category-add.js
+++ b/src/bot/commands/admin/category-add.js
@@ -6,7 +6,7 @@ export default createCommand({
   name: 'category add',
   description: 'Add a new skill category.',
   usage: '<category name>',
-}, createParser(({args}, {bot, token, getCommand}) => {
+}, createParser(({args}, {token}) => {
   const search = args.join(' ');
   if (!search) {
     return false;

--- a/src/bot/commands/admin/category-enable-disable.js
+++ b/src/bot/commands/admin/category-enable-disable.js
@@ -2,7 +2,7 @@ import {query} from '../../../services/db';
 import {createCommand, createParser} from 'chatter';
 import {getBestMatch} from '../../lib/matching';
 
-const activateHander = isActive => ({args}, {token}) => {
+const getHandler = isActive => ({args}, {token}) => {
   const search = args.join(' ');
   if (!search) {
     return false;
@@ -20,23 +20,23 @@ const activateHander = isActive => ({args}, {token}) => {
     if (!match) {
       return buffer;
     }
-    // Deactivate the category.
+    // Enable or disable the category.
     return query.categorySetActive({categoryId: match.id, isActive})
     .then(() => [
       ...buffer,
-      `_You have successfully ${isActive ? '' : 'de'}activated category "${search}"._`,
+      `_You have successfully ${isActive ? 'enabled' : 'disabled'} category "${search}"._`,
     ]);
   });
 };
 
-export const categoryActivate = createCommand({
-  name: 'category activate',
-  description: 'Activate a skill category.',
+export const categoryEnable = createCommand({
+  name: 'category enable',
+  description: 'Enable a skill category.',
   usage: '<category name>',
-}, createParser(activateHander(true)));
+}, createParser(getHandler(true)));
 
-export const categoryDeactivate = createCommand({
-  name: 'category deactivate',
-  description: 'Deactivate a skill category.',
+export const categoryDisable = createCommand({
+  name: 'category disable',
+  description: 'Disable a skill category.',
   usage: '<category name>',
-}, createParser(activateHander(false)));
+}, createParser(getHandler(false)));

--- a/src/bot/commands/admin/category-info.js
+++ b/src/bot/commands/admin/category-info.js
@@ -31,7 +31,7 @@ export default createCommand({
       const p = pluralizeOn(skills.length);
       return [
         `The category name is *${name}*`,
-        `The category state is *${isActive ? 'active' : 'deactivated'}*.`,
+        `The category state is *${isActive ? 'enabled' : 'disabled'}*.`,
         `There ${p('is/are')} *${p}* skill${p()} that belong to this category:`,
         `> ${skills.join(', ')}`,
       ];

--- a/src/bot/commands/admin/category-info.js
+++ b/src/bot/commands/admin/category-info.js
@@ -1,0 +1,40 @@
+import {query, one} from '../../../services/db';
+import {createCommand, createParser} from 'chatter';
+import {getBestMatch} from '../../lib/matching';
+import {pluralizeOn} from '../../../util/localization';
+
+export default createCommand({
+  name: 'category info',
+  description: 'Get information about a category.',
+  usage: '<category name>',
+}, createParser(({args}, {token}) => {
+  const search = args.join(' ');
+  if (!search) {
+    return false;
+  }
+  // Create a buffer in which output messages can accumulate.
+  const buffer = [];
+  // Find matching categories.
+  return query.categoryByName({token, search})
+  .then(matches => {
+    // Test if match is good, ambiguous, etc.
+    const {match, output} = getBestMatch(search, matches);
+    // Add any output from the test to the buffer.
+    buffer.push(output);
+    // Exit now if match was ambiguous.
+    if (!match) {
+      return buffer;
+    }
+    console.log(match);
+    return one.categoryInfo({categoryId: match.id})
+    .then(({name, skills, is_active: isActive}) => {
+      const p = pluralizeOn(skills.length);
+      return [
+        `The category name is *${name}*`,
+        `The category state is *${isActive ? 'active' : 'deactivated'}*.`,
+        `There ${p('is/are')} *${p}* skill${p()} that belong to this category:`,
+        `> ${skills.join(', ')}`,
+      ];
+    });
+  });
+}));

--- a/src/bot/commands/admin/category-list.js
+++ b/src/bot/commands/admin/category-list.js
@@ -22,8 +22,8 @@ export default createCommand({
       return 'No skill categories have been defined for your team yet.';
     }
     return [
-      formatCategory('Active', active),
-      formatCategory('Inactive', inactive),
+      formatCategory('Enabled', active),
+      formatCategory('Disabled', inactive),
     ];
   });
 });

--- a/src/bot/commands/admin/category-list.js
+++ b/src/bot/commands/admin/category-list.js
@@ -1,0 +1,30 @@
+import {one} from '../../../services/db';
+import {createCommand} from 'chatter';
+
+const pluralizeOn = n => s => s.split('/')[Number(Number(n) !== 1)];
+
+function formatCategory(header, arr) {
+  const items = arr.length === 0 ? ['(none)'] : arr.map(([name, skillsCount]) => {
+    const p = pluralizeOn(skillsCount);
+    return `${name} (${skillsCount} skill${p('/s')})`;
+  });
+  return [
+    `*${header} categories*`,
+    ...items.map(s => `> ${s}`),
+  ];
+}
+
+export default createCommand({
+  name: 'category list',
+  description: 'List all skill categories.',
+}, (message, {token}) => {
+  return one.categoriesForTeam({token}).then(({active, inactive}) => {
+    if (active.length === 0 && inactive.length === 0) {
+      return 'No skill categories have been defined for your team yet.';
+    }
+    return [
+      formatCategory('Active', active),
+      formatCategory('Inactive', inactive),
+    ];
+  });
+});

--- a/src/bot/commands/admin/category-list.js
+++ b/src/bot/commands/admin/category-list.js
@@ -1,12 +1,11 @@
 import {one} from '../../../services/db';
 import {createCommand} from 'chatter';
-
-const pluralizeOn = n => s => s.split('/')[Number(Number(n) !== 1)];
+import {pluralizeOn} from '../../../util/localization';
 
 function formatCategory(header, arr) {
   const items = arr.length === 0 ? ['(none)'] : arr.map(([name, skillsCount]) => {
     const p = pluralizeOn(skillsCount);
-    return `${name} (${skillsCount} skill${p('/s')})`;
+    return `${name} (${p} skill${p()})`;
   });
   return [
     `*${header} categories*`,

--- a/src/bot/commands/admin/category-update.js
+++ b/src/bot/commands/admin/category-update.js
@@ -1,9 +1,9 @@
 import {createCommand, createParser} from 'chatter';
 
 export default createCommand({
-  name: 'update category',
-  description: 'Update a new skills category.',
+  name: 'category update',
+  description: 'Update a new skill category.',
   usage: '<category name>',
 }, createParser(({args}) => {
-  return 'update category command coming soon';
+  return 'update command coming soon';
 }));

--- a/src/bot/commands/admin/deactivate-category.js
+++ b/src/bot/commands/admin/deactivate-category.js
@@ -1,9 +1,0 @@
-import {createCommand, createParser} from 'chatter';
-
-export default createCommand({
-  name: 'deactivate category',
-  description: 'Deactivate a new skills category.',
-  usage: '<category name>',
-}, createParser(({args}) => {
-  return 'deactivate category command coming soon';
-}));

--- a/src/bot/jobs.js
+++ b/src/bot/jobs.js
@@ -2,10 +2,9 @@ import {createMatcher} from 'chatter';
 
 import Scheduler from '../util/scheduler';
 import {query} from '../services/db';
+import {pluralizeOn} from '../util/localization';
 
 export const jobs = new Scheduler();
-
-const pluralizeOn = n => s => s.split('/')[Number(n !== 1)];
 
 export function notifyMissing({bot, token, debug} = {}) {
   const buffer = [];
@@ -27,7 +26,7 @@ export function notifyMissing({bot, token, debug} = {}) {
     const cmdPrefix = dmId ? '' : `/msg <@${bot.slack.rtmClient.activeUserId}> `;
     // Construct the message for this user.
     const message = [
-      `*You have ${skills.length} outstanding skill${p('/s')} that need${p('s/')} to be updated.*`,
+      `*You have ${p} outstanding skill${p()} that need${p('s/')} to be updated.*`,
       `Please update ${p('it/them')} with \`${cmdPrefix}update missing\`.`,
     ];
     // If in debug mode, buffer the message instead of actually sending it.
@@ -40,7 +39,7 @@ export function notifyMissing({bot, token, debug} = {}) {
   // Done.
   .then(results => {
     const p = pluralizeOn(results.length);
-    push(`Job done, ${results.length} user${p('/s')} processed.`);
+    push(`Job done, ${p} user${p()} processed.`);
   })
   // Handle errors.
   .catch(e => push(`Error: ${e.message}`))

--- a/src/sql/categories_for_team.sql
+++ b/src/sql/categories_for_team.sql
@@ -1,0 +1,15 @@
+WITH categories AS (
+  SELECT
+    cat.name,
+    COUNT(sk) AS skills_count,
+    cat.is_active
+  FROM skill_category cat
+  INNER JOIN slack_team team ON (team.id = cat.slack_team_id)
+  LEFT JOIN skill sk ON (sk.skill_category_id = cat.id)
+  WHERE team.token = ${token}
+  GROUP BY cat.name, cat.is_active
+  ORDER BY cat.name
+)
+SELECT
+  (SELECT COALESCE(ARRAY_AGG(ARRAY[name, skills_count::text]), '{}') FROM categories WHERE is_active = true) AS active,
+  (SELECT COALESCE(ARRAY_AGG(ARRAY[name, skills_count::text]), '{}') FROM categories WHERE is_active = false) AS inactive

--- a/src/sql/category_by_name.sql
+++ b/src/sql/category_by_name.sql
@@ -1,4 +1,7 @@
-SELECT name
-FROM skill_category
+SELECT
+  cat.id,
+  cat.name,
+  cat.is_active
+FROM skill_category cat
 INNER JOIN slack_team team ON (team.id = slack_team_id)
 WHERE team.token = ${token} AND name ILIKE '%'||${search}::text||'%'

--- a/src/sql/category_info.sql
+++ b/src/sql/category_info.sql
@@ -1,0 +1,9 @@
+SELECT
+  cat.id,
+  cat.name,
+  cat.is_active,
+  ARRAY_AGG(sk.name ORDER BY sk.name) AS skills
+FROM skill_category cat
+INNER JOIN skill sk ON (sk.skill_category_id = cat.id)
+WHERE cat.id = ${categoryId}
+GROUP BY cat.id, cat.name, cat.is_active

--- a/src/sql/category_set_active.sql
+++ b/src/sql/category_set_active.sql
@@ -1,0 +1,3 @@
+UPDATE skill_category
+SET is_active = ${isActive}
+WHERE id = ${categoryId}

--- a/src/sql/skills_by_category.sql
+++ b/src/sql/skills_by_category.sql
@@ -1,9 +1,31 @@
-SELECT
-  cat.name AS name,
-  ARRAY_AGG(sk.name ORDER BY sk.name) AS skills
-FROM skill sk
-INNER JOIN skill_category cat ON (sk.skill_category_id = cat.id)
-INNER JOIN slack_team team ON (cat.slack_team_id = team.id)
-WHERE team.token = ${token} AND cat.parent_id IS NULL
-GROUP BY cat.name
-ORDER BY cat.name
+WITH skills_categories AS (
+  SELECT
+    sk.name AS skill,
+    cat.name AS name,
+    cat.is_active AS category_is_active
+  FROM skill sk
+  INNER JOIN skill_category cat ON (sk.skill_category_id = cat.id)
+  INNER JOIN slack_team team ON (cat.slack_team_id = team.id)
+  WHERE team.token = ${token}
+  AND cat.parent_id IS NULL
+)
+SELECT name, skills FROM (
+  (
+    SELECT
+      name,
+      1 AS sort,
+      ARRAY_AGG(skill ORDER BY skill) AS skills
+    FROM skills_categories
+    WHERE category_is_active = true
+    GROUP BY name
+  ) UNION (
+    SELECT
+      'Uncategorized' AS name,
+      2 AS sort,
+      ARRAY_AGG(skill ORDER BY skill) AS skills
+    FROM skills_categories
+    WHERE category_is_active = false
+    HAVING COUNT(*) > 1
+  )
+  ORDER BY sort, name
+) tbl

--- a/src/util/localization.js
+++ b/src/util/localization.js
@@ -1,0 +1,20 @@
+// TODO: use a real localization library.
+
+// Usage
+//
+// function test(length) {
+//   const p = pluralizeOn(length);
+//   return `There ${p('is/are')} ${p} thing{p()}.`);
+// }
+//
+// test(1) // "There is 1 thing."
+// test(2) // "There are 2 things."
+export function pluralizeOn(num) {
+  function fn(str = '/s') {
+    const parts = str.split('/');
+    const index = Number(Number(num) !== 1);
+    return parts[index];
+  }
+  fn.toString = () => num;
+  return fn;
+}


### PR DESCRIPTION
I'm re-implementing PR #56 because a lot has changed since that was started.

This PR:
- Adds a `skill_category`-specific `is_active` migration (`skill` will be done in a future PR)
- Renames the existing in-progress category admin commands to the following:
  - `admin category add`
  - `admin category update`
  - `admin category activate`
  - `admin category deactivate`
- Adds the following commands, because they seemed helpful:
  - `admin category list` - List all skill categories.
  - `admin category info` - Get information about a category.
- Modifies the `list` command to:
  - show still-active skills in deactivated categories under a `Uncategorized` header

The following commands have been implemented:
- [x] `admin category list`
- [x] `admin category info`
- [x] `admin category add` (closes #39)
- [ ] `admin category update` (not done yet)
- [x] `admin category activate` (closes #41)
- [x] `admin category deactivate` (closes #40)

Question:
- Can I change the terminology from **activate/activated** and **deactivate/deactivated** to **enable/enabled** and **disable/disabled**?

That would change the following:
- `admin category activate` would become  `admin category enable`
- `admin category deactivate` would become  `admin category disable`
- (plus a handful of newly-added strings would change)
